### PR TITLE
security: harden docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     ports:
       - "${PORT:-3000}:3000"  # Health check endpoint
     restart: unless-stopped
+    # Security hardening
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:mode=1777,size=64M
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Add read-only filesystem to prevent container writes
- Add no-new-privileges security option
- Add tmpfs mount for /tmp for temporary files

## Fixes
Resolves Semgrep security findings:
- `yaml.docker-compose.security.writable-filesystem-service`
- `yaml.docker-compose.security.no-new-privileges`

## Test plan
- [ ] Verify container starts successfully with new security options
- [ ] Confirm health check endpoint still works
- [ ] Test bot functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)